### PR TITLE
Update dependencies version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,6 +28,8 @@
 
   <properties>
     <netty.version>4.1.49.Final</netty.version>
+    <gson.version>2.2.4</gson.version>
+    <jackson.version>2.11.3</jackson.version>
     <vertx.version>3.9.5</vertx.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>
@@ -92,19 +94,19 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.2.4</version>
+      <version>${gson.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.0</version>
+      <version>${jackson.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.0</version>
+      <version>${jackson.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <properties>
-    <netty.version>4.1.49.Final</netty.version>
+    <netty.version>4.1.52.Final</netty.version>
     <gson.version>2.2.4</gson.version>
     <jackson.version>2.11.3</jackson.version>
     <vertx.version>3.9.5</vertx.version>


### PR DESCRIPTION
Motivation:

This PR upgrades:
* Netty from `4.1.49.Final` to `4.1.52.Final`
* Jackson from `2.9.0` to `2.11.3`

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
