### PR TITLE
C client must recieve length buffer as unsigned char

### DIFF
--- a/C/lib/vertx.c
+++ b/C/lib/vertx.c
@@ -289,7 +289,7 @@ void recieve_frame(void *i)
       if (FD_ISSET(SendingSocket, &read_fd_set))
       {
         //lock
-        char length_buffer[4];
+        unsigned char length_buffer[4];
         retVal = osi_socket_read(SendingSocket, length_buffer, 4);
         if (retVal > 0)
         {

--- a/C/vertx.c
+++ b/C/vertx.c
@@ -266,7 +266,7 @@ void recieve_frame(void * i){
 		  
             if (FD_ISSET (SendingSocket, &read_fd_set)){
                 //lock
-                char length_buffer[4];
+                unsigned char length_buffer[4];
                 retVal = osi_socket_read(SendingSocket, length_buffer, 4);
                 if ( retVal > 0 ){
                     unsigned int num=0,num1=0,num2=0,num3=0;


### PR DESCRIPTION
Motivation:

When length recieved in length buffer is greater than 128, this length is handled as negative value and then casted in an unsigned value.
This results with a huge array stack allocation and make the client crash.

